### PR TITLE
Add PUT/POST methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Dependency directories
+node_modules/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A lightweight Node.js wrapper for Jamf Pro's JSS REST API.
 
 ## Scope
 
-Currently this module only supports `GET`, `PUT`, and `POST` requests for the JSS REST API. [Support `DELETE` will be added later](https://github.com/mapbox/node-jamf/issues/6).
+Currently this module only supports `GET`, `PUT`, and `POST` requests for the JSS REST API. [Support for `DELETE` will be added later](https://github.com/mapbox/node-jamf/issues/6).
 
 [Support for the JSS Universal API](https://github.com/mapbox/node-jamf/issues/5) may also be added later.
 
@@ -100,4 +100,5 @@ All of your tests should pass both locally and in Travis before we'll accept you
 ## Resources
 
 * You can see all available Jamf API calls by accessing `/api` on your JSS instance. For example, visit `https://yourdomain.jamfcloud.com/api`. This page also contains an API playground where you can test out requests.
-* [The Unofficial Jamf API Docs](https://unofficial-jss-api-docs.atlassian.net/wiki)
+* [Jamf API Documentation]https://developer.jamf.com/documentation
+* [Casper API Command Line Tool]https://github.com/eventbrite/Casper-API-Tools - good reference for XML structure for `PUT` and `POST`.

--- a/README.md
+++ b/README.md
@@ -100,5 +100,5 @@ All of your tests should pass both locally and in Travis before we'll accept you
 ## Resources
 
 * You can see all available Jamf API calls by accessing `/api` on your JSS instance. For example, visit `https://yourdomain.jamfcloud.com/api`. This page also contains an API playground where you can test out requests.
-* [Jamf API Documentation]https://developer.jamf.com/documentation
-* [Casper API Command Line Tool]https://github.com/eventbrite/Casper-API-Tools - good reference for XML structure for `PUT` and `POST`.
+* [Jamf API Documentation](https://developer.jamf.com/documentation)
+* [Casper API Command Line Tool](https://github.com/eventbrite/Casper-API-Tools) - good reference for XML structure for `PUT` and `POST`.

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ A lightweight Node.js wrapper for Jamf Pro's JSS REST API.
 
 ## Scope
 
-Currently this module only supports `GET` requests for the JSS REST API. [Support for other methods such as `PUT`, `POST`, and `DELETE` will be added later](https://github.com/mapbox/node-jamf/issues/6).
+Currently this module only supports `GET`, `PUT`, and `POST` requests for the JSS REST API. [Support `DELETE` will be added later](https://github.com/mapbox/node-jamf/issues/6).
 
 [Support for the JSS Universal API](https://github.com/mapbox/node-jamf/issues/5) may also be added later.
 
-## Installation 
+## Installation
 
 `npm install jamf`
 
@@ -56,7 +56,7 @@ You need to configure the Jamf API client before it can make any API calls. You'
 * `user`: username for the JSS user accessing the Jamf API
 * `password`: password for the above account
 * `jamfUrl`: the URL of your JSS instance, whether on premise or in the cloud (`https://yourdomain.jamfcloud.com`)
-* `format`: the format of the returned data, must be either `xml` (Jamf API default) or `json`
+* `format`: the format of the returned data, must be either `xml` (Jamf API default) or `json`. `PUT` and `POST` methods always return xml,
 
 We recommend you create a new dedicated, least privilege API user for these scripts. The user must have the necessary privileges (create, read, update, or delete) on the JSS objects
 

--- a/examples/client.js
+++ b/examples/client.js
@@ -26,3 +26,17 @@ jamf.get('/osxconfigurationprofiles/id/3/subset/Scopes', function (err, res){
   if (err) console.log(err)
   console.log(res)
 });
+
+// Add mobile device #85 to group #17
+var xml = '<?xml version="1.0" encoding="UTF-8"?><mobile_device_group><mobile_device_additions><mobile_device><id>85</id></mobile_device></mobile_device_additions></mobile_device_group>';
+jamf.put('/mobiledevicegroups/id/17', xml, function (err, res){
+  if (err) console.log(err)
+  console.log(res)
+});
+
+// Send a blank push to mobile device #85
+var xml = ''; // Not all device commands require XML
+jamf.post('/mobiledevicecommands/command/BlankPush/id/85', xml, function(err, res){
+  if (err) console.log(err)
+  console.log(res)
+});

--- a/lib/jamfclient.js
+++ b/lib/jamfclient.js
@@ -75,6 +75,63 @@ JamfApiClient.prototype = {
         }
       }
     });
+  },
+  post: function(path, xml, callback) {
+
+    var requestUrl = this.config.jamfUrl + '/JSSResource' + path;
+
+    var requestOptions = {
+      'method': 'POST',
+      'auth': {
+        'user': this.config.user,
+        'pass': this.config.password,
+        'sendImmediately': false
+      }
+    }
+
+    if (xml !== '') {
+      requestOptions.body = xml;
+    }
+
+    request(requestUrl, requestOptions, function(error, response, body){
+      if (!_.includes(successCodes, response.statusCode)) {
+        var error = new Error(response.statusCode + ' ' + response.statusMessage);
+      }
+      if (error) {
+        callback(error, null);
+      } else {
+        callback(null, body);
+      }
+    });
+  },
+  put: function(path, xml, callback) {
+
+    var requestUrl = this.config.jamfUrl + '/JSSResource' + path;
+
+    var requestOptions = {
+      'method': 'PUT',
+      'auth': {
+        'user': this.config.user,
+        'pass': this.config.password,
+        'sendImmediately': false
+      },
+      headers: {
+        'Content-Type': 'text/xml',
+        'Accept': 'text/xml'
+      },
+      body: xml
+    }
+
+    request(requestUrl, requestOptions, function(error, response, body){
+      if (!_.includes(successCodes, response.statusCode)) {
+        var error = new Error(response.statusCode + ' ' + response.statusMessage);
+      }
+      if (error) {
+        callback(error, null);
+      } else {
+        callback(null, body);
+      }
+    });
   }
 }
 


### PR DESCRIPTION
This PR includes two new methods, `post` and `put` on the JamfApiClient object prototype. It also includes two usage examples in `examples/client.js`. It does not yet include any test fixtures - I'm willing to add them, just need a bit of direction on what you want to see tests for. I've been actively using both of these new methods (along with get) for a little while now.

ref: issue #6 
